### PR TITLE
static analysis fixes from psalm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "vimeo/psalm": "*"
+    },
     "suggest": {
         "ext-thrift_protocol": "Enabling the thrift protocol extension is crucial for phpcassa's performance"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "vimeo/psalm": "*"
+        "vimeo/psalm": "*",
+        "phpunit/phpunit": "5.*"
     },
     "suggest": {
         "ext-thrift_protocol": "Enabling the thrift protocol extension is crucial for phpcassa's performance"

--- a/lib/Thrift/ClassLoader/ThriftClassLoader.php
+++ b/lib/Thrift/ClassLoader/ThriftClassLoader.php
@@ -35,7 +35,7 @@ class ThriftClassLoader
 
     /**
      * Thrift definition paths
-     * @var type
+     * @var array
      */
     protected $definitions = array();
 
@@ -87,7 +87,7 @@ class ThriftClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param Boolean $prepend Whether to prepend the autoloader or not
+     * @param boolean $prepend Whether to prepend the autoloader or not
      */
     public function register($prepend = false)
     {

--- a/lib/Thrift/Factory/TProtocolFactory.php
+++ b/lib/Thrift/Factory/TProtocolFactory.php
@@ -29,7 +29,7 @@ interface TProtocolFactory {
   /**
    * Build a protocol from the base transport
    *
-   * @return Thrift\Protocol\TProtocol protocol
+   * @return \Thrift\Protocol\TProtocol protocol
    */
   public function getProtocol($trans);
 }

--- a/lib/Thrift/Factory/TStringFuncFactory.php
+++ b/lib/Thrift/Factory/TStringFuncFactory.php
@@ -23,6 +23,7 @@ namespace Thrift\Factory;
 
 use Thrift\StringFunc\Mbstring;
 use Thrift\StringFunc\Core;
+use Thrift\StringFunc\TStringFunc;
 
 class TStringFuncFactory {
     private static $_instance;

--- a/lib/Thrift/Protocol/TJSONProtocol.php
+++ b/lib/Thrift/Protocol/TJSONProtocol.php
@@ -26,6 +26,8 @@ namespace Thrift\Protocol;
 use Thrift\Protocol\TProtocol;
 use Thrift\Type\TType;
 use Thrift\Exception\TProtocolException;
+use Thrift\Exception\TException;
+
 use Thrift\Protocol\JSON\BaseContext;
 use Thrift\Protocol\JSON\LookaheadReader;
 use Thrift\Protocol\JSON\PairContext;

--- a/lib/Thrift/Protocol/TProtocol.php
+++ b/lib/Thrift/Protocol/TProtocol.php
@@ -22,6 +22,7 @@
 
 namespace Thrift\Protocol;
 
+use Thrift\Transport\TTransport;
 use Thrift\Type\TType;
 use Thrift\Exception\TProtocolException;
 

--- a/lib/Thrift/Protocol/TProtocol.php
+++ b/lib/Thrift/Protocol/TProtocol.php
@@ -22,6 +22,7 @@
 
 namespace Thrift\Protocol;
 
+use Thirft\Exception\TException;
 use Thrift\Transport\TTransport;
 use Thrift\Type\TType;
 use Thrift\Exception\TProtocolException;

--- a/lib/Thrift/Server/TServer.php
+++ b/lib/Thrift/Server/TServer.php
@@ -16,7 +16,7 @@ abstract class TServer {
   /**
    * Processor to handle new clients
    *
-   * @var TProcessor
+   * @var mixed
    */
   protected $processor_;
 

--- a/lib/Thrift/Server/TServerTransport.php
+++ b/lib/Thrift/Server/TServerTransport.php
@@ -3,6 +3,7 @@
 namespace Thrift\Server;
 
 use Thrift\Exception\TTransportException;
+use Thrift\Transport\TTransport;
 
 /**
  * Generic class for Server agent.

--- a/lib/Thrift/Transport/TTransport.php
+++ b/lib/Thrift/Transport/TTransport.php
@@ -23,7 +23,7 @@
 namespace Thrift\Transport;
 
 use Thrift\Factory\TStringFuncFactory;
-
+use Thrift\Exception\TTransportException;
 /**
  * Base interface for a transport agent.
  *

--- a/lib/phpcassa/AbstractColumnFamily.php
+++ b/lib/phpcassa/AbstractColumnFamily.php
@@ -155,7 +155,7 @@ abstract class AbstractColumnFamily {
     /**
      * Constructs a ColumnFamily.
      *
-     * @param phpcassa\Connection\ConnectionPool $pool the pool to use when
+     * @param \phpcassa\Connection\ConnectionPool $pool the pool to use when
      *        querying Cassandra
      * @param string $column_family the name of the column family in Cassandra
      * @param bool $autopack_names whether or not to automatically convert column names
@@ -513,7 +513,7 @@ abstract class AbstractColumnFamily {
      *        server will overallocate memory and fail.  This is the size of
      *        that buffer in number of rows.
      *
-     * @return phpcassa\Iterator\RangeColumnFamilyIterator
+     * @return \phpcassa\Iterator\RangeColumnFamilyIterator
      */
     public function get_range($key_start="",
         $key_finish="",
@@ -535,8 +535,7 @@ abstract class AbstractColumnFamily {
         if ($buffsz == null)
             $buffsz = $this->buffer_size;
         if ($buffsz < 2) {
-            $ire = new InvalidRequestException();
-            $ire->message = 'buffer_size cannot be less than 2';
+            $ire = new InvalidRequestException('buffer_size cannot be less than 2');
             throw $ire;
         }
 
@@ -576,7 +575,7 @@ abstract class AbstractColumnFamily {
      *        server will overallocate memory and fail.  This is the size of
      *        that buffer in number of rows.
      *
-     * @return phpcassa\Iterator\RangeColumnFamilyIterator
+     * @return \phpcassa\Iterator\RangeColumnFamilyIterator
      */
     public function get_range_by_token($token_start="",
                               $token_finish="",
@@ -598,8 +597,7 @@ abstract class AbstractColumnFamily {
         if ($buffsz == null)
             $buffsz = $this->buffer_size;
         if ($buffsz < 2) {
-            $ire = new InvalidRequestException();
-            $ire->message = 'buffer_size cannot be less than 2';
+            $ire = new InvalidRequestException('buffer_size cannot be less than 2');
             throw $ire;
         }
 
@@ -614,14 +612,14 @@ abstract class AbstractColumnFamily {
     /**
      * Fetch a set of rows from this column family based on an index clause.
      *
-     * @param phpcassa\Index\IndexClause $index_clause limits the keys that are returned based
+     * @param \phpcassa\Index\IndexClause $index_clause limits the keys that are returned based
      *        on expressions that compare the value of a column to a given value.  At least
      *        one of the expressions in the IndexClause must be on an indexed column.
-     * @param phpcassa\ColumnSlice a slice of columns to fetch, or null
+     * @param \phpcassa\ColumnSlice a slice of columns to fetch, or null
      * @param mixed[] $column_names limit the columns or super columns fetched to this list
      * number of nodes that must respond before the operation returns
      *
-     * @return phpcassa\Iterator\IndexedColumnFamilyIterator
+     * @return \phpcassa\Iterator\IndexedColumnFamilyIterator
      */
     public function get_indexed_slices($index_clause,
         $column_slice=null,
@@ -632,8 +630,7 @@ abstract class AbstractColumnFamily {
         if ($buffer_size == null)
             $buffer_size = $this->buffer_size;
         if ($buffer_size < 2) {
-            $ire = new InvalidRequestException();
-            $ire->message = 'buffer_size cannot be less than 2';
+            $ire = new InvalidRequestException('buffer_size cannot be less than 2');
             throw $ire;
         }
 
@@ -721,7 +718,7 @@ abstract class AbstractColumnFamily {
                     $this->make_mutation($columns, $timestamp, $ttlRow);
             }
         } else {
-            throw new UnexpectedValueException("Bad insert_format selected");
+            throw new \UnexpectedValueException("Bad insert_format selected");
         }
 
         return $this->pool->call("batch_mutate", $cfmap, $this->wcl($consistency_level));
@@ -731,10 +728,10 @@ abstract class AbstractColumnFamily {
      * Create a new phpcassa\Batch\CfMutator instance targetting this column
      * family.
      *
-     * @param phpcassa\ConsistencyLevel $consistency_level the consistency
+     * @param ConsistencyLevel $consistency_level the consistency
      *        level the batch mutator will write at; if left as NULL, this
      *        defaults to phpcassa\ColumnFamily::write_consistency_level.
-     * @return a phpcassa\Batch\CfMutator instance
+     * @return \phpcassa\Batch\CfMutator instance
      */
     public function batch($consistency_level=null) {
         return new CfMutator($this, $consistency_level);
@@ -1107,7 +1104,7 @@ abstract class AbstractColumnFamily {
         } else if ($this->insert_format == self::ARRAY_FORMAT) {
             return $this->array_to_coscs($data, $timestamp, $ttl);
         } else {
-            throw new UnexpectedValueException("Bad insert_format selected");
+            throw new \UnexpectedValueException("Bad insert_format selected");
         }
     }
 

--- a/lib/phpcassa/Batch/AbstractMutator.php
+++ b/lib/phpcassa/Batch/AbstractMutator.php
@@ -22,7 +22,7 @@ abstract class AbstractMutator
      * If an error occurs, the buffer will be preserverd, allowing you to
      * attempt to call send() again later or take other recovery actions.
      *
-     * @param cassandra\ConsistencyLevel $consistency_level optional
+     * @param \cassandra\ConsistencyLevel $consistency_level optional
      *        override for the mutator's default consistency level
      */
     public function send($consistency_level=null) {

--- a/lib/phpcassa/Batch/CfMutator.php
+++ b/lib/phpcassa/Batch/CfMutator.php
@@ -1,6 +1,7 @@
 <?php
 namespace phpcassa\Batch;
 
+use cassandra\ConsistencyLevel;
 use phpcassa\Batch\AbstractMutator;
 
 /**
@@ -16,10 +17,10 @@ class CfMutator extends AbstractMutator {
     /**
      * Initialize a mutator for a given column family.
      *
-     * @param phpcassa\ColumnFamily $column_family an initialized instanced
+     * @param \phpcassa\ColumnFamily $column_family an initialized instanced
      *        of ColumnFamily; this object's pool will be used for all
      *        operations.
-     * @param phpcassa\ConsistencyLevel $write_consistency_level the consistency
+     * @param ConsistencyLevel $write_consistency_level the consistency
      *        level this mutator will write at; if left as NULL, this defaults to
      *        $column_family->write_consistency_level.
      */

--- a/lib/phpcassa/Batch/Mutator.php
+++ b/lib/phpcassa/Batch/Mutator.php
@@ -14,9 +14,9 @@ class Mutator extends AbstractMutator
     /**
      * Intialize a mutator with a connection pool and consistency level.
      *
-     * @param phpcassa\Connection\ConnectionPool $pool the connection pool to
+     * @param \phpcassa\Connection\ConnectionPool $pool the connection pool to
      *        use for all operations
-     * @param cassandra\ConsistencyLevel $consistency_level the default consistency
+     * @param int  $consistency_level the default consistency
      *        level this mutator will write at, with a default of
      *        ConsistencyLevel::ONE
      */
@@ -30,7 +30,7 @@ class Mutator extends AbstractMutator
     /**
      * Add an insertion to the buffer.
      *
-     * @param phpcassa\ColumnFamily $column_family an initialized
+     * @param \phpcassa\ColumnFamily $column_family an initialized
      *        ColumnFamily instance
      * @param mixed $key the row key
      * @param mixed[] $columns an array of columns to insert, whose format
@@ -46,7 +46,7 @@ class Mutator extends AbstractMutator
     /**
      * Add a deletion to the buffer.
      *
-     * @param phpcassa\ColumnFamily $column_family an initialized
+     * @param \phpcassa\ColumnFamily $column_family an initialized
      *        ColumnFamily instance
      * @param mixed $key the row key
      * @param mixed[] $columns a list of columns or super columns to delete

--- a/lib/phpcassa/Index/IndexClause.php
+++ b/lib/phpcassa/Index/IndexClause.php
@@ -11,7 +11,7 @@ class IndexClause extends \cassandra\IndexClause {
     /**
      * Constructs an index clause for use with get_indexed_slices().
      *
-     * @param phpcassa\Index\IndexExpression[] $expr_list the list of expressions
+     * @param IndexExpression[] $expr_list the list of expressions
      *        to match; at least one of these must be on an indexed column
      * @param mixed $start_key the key to begin searching from
      * @param int $count the number of results to return

--- a/lib/phpcassa/Schema/DataType/CompositeType.php
+++ b/lib/phpcassa/Schema/DataType/CompositeType.php
@@ -12,7 +12,7 @@ use phpcassa\ColumnFamily;
 class CompositeType extends CassandraType implements Serialized
 {
     /**
-     * @param phpcassa\Schema\DataType\CassandraType[] $inner_types an array
+     * @param \phpcassa\Schema\DataType\CassandraType[] $inner_types an array
      *        of other CassandraType instances.
      */
     public function __construct($inner_types) {
@@ -83,7 +83,7 @@ class CompositeType extends CassandraType implements Serialized
 
     public function __toString() {
         $inner_strs = array();
-        foreach ($inner_types as $inner_type) {
+        foreach ($this->inner_types as $inner_type) {
             $inner_strs[] = (string)$inner_type;
         }
 

--- a/lib/phpcassa/Schema/DataType/UUIDType.php
+++ b/lib/phpcassa/Schema/DataType/UUIDType.php
@@ -20,7 +20,7 @@ class UUIDType extends CassandraType implements Serialized
         if (!$is_uuid && is_string($value)) {
             try {
                 $value = UUID::import($value);
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 throw new UUIDException("Error casting '$value' to UUID: $e");
             }
         } else if (!$is_uuid) {

--- a/lib/phpcassa/SuperColumnFamily.php
+++ b/lib/phpcassa/SuperColumnFamily.php
@@ -1,6 +1,7 @@
 <?php
 namespace phpcassa;
 
+use cassandra\ConsistencyLevel;
 use phpcassa\ColumnFamily;
 use phpcassa\ColumnSlice;
 
@@ -150,7 +151,7 @@ class SuperColumnFamily extends AbstractColumnFamily {
      *        server will overallocate memory and fail.  This is the size of
      *        that buffer in number of rows.
      *
-     * @return phpcassa\Iterator\RangeColumnFamilyIterator
+     * @return \phpcassa\Iterator\RangeColumnFamilyIterator
      */
     public function get_super_column_range($super_column,
                                            $key_start="",

--- a/lib/phpcassa/SystemManager.php
+++ b/lib/phpcassa/SystemManager.php
@@ -441,7 +441,7 @@ class SystemManager {
      *
      * @param string $keyspace the keyspace name
      *
-     * @return cassandra\KsDef
+     * @return \cassandra\KsDef
      */
     public function describe_keyspace($keyspace) {
         return $this->client->describe_keyspace($keyspace);
@@ -450,7 +450,7 @@ class SystemManager {
     /**
      * Like describe_keyspace(), but for all keyspaces.
      *
-     * @return array an array of cassandra\KsDef
+     * @return \cassandra\KsDef[]
      */
     public function describe_keyspaces() {
         return $this->client->describe_keyspaces();

--- a/lib/phpcassa/UUID.php
+++ b/lib/phpcassa/UUID.php
@@ -342,12 +342,12 @@ class UUID {
    self::$randomSource = fopen('/dev/urandom', 'rb');
    self::$randomFunc = 'randomFRead';
   }
-  else if (class_exists('COM', 0)) {
+  else if (class_exists('\COM', 0)) {
    try {
-    self::$randomSource = new COM('CAPICOM.Utilities.1');  // See http://msdn.microsoft.com/en-us/library/aa388182(VS.85).aspx
+    self::$randomSource = new \COM('CAPICOM.Utilities.1');  // See http://msdn.microsoft.com/en-us/library/aa388182(VS.85).aspx
     self::$randomFunc = 'randomCOM';
    }
-   catch(Exception $e) {}
+   catch(\Exception $e) {}
   }
   return self::$randomFunc;
  } 


### PR DESCRIPTION
I ran psalm 3.0.x over a legacy project which uses this as a library; it exploded ... so I've fixed the various issues with this codebase. They're nearly all -

 * Incorrect phpdoc annotation (E.g. @param foo\bar instead of @param \foo\bar)
 * Accessing protected variable on an exception class (E.g. ```$f = new Exception(); $f->message = "some error"``` ... which should be``` $f = new Exception("some error");``` )
  * Incorrect class name (E.g ... ```throw new Exception(..)``` where there isn't an Exception class in the current namespace and it should presumably be ```throw new \Exception(...)```